### PR TITLE
Add optional resource route filtering with 'only:'

### DIFF
--- a/src/exprestive.coffee
+++ b/src/exprestive.coffee
@@ -93,21 +93,38 @@ class Exprestive
       url.replace ':id', id
 
 
-  # A helper method for automatically binding restful controllers in a routes file
-  # This is passed as "resources" to the routes file function parameter hash
-  resourcesDirective: (controllerName) =>
+  # Full list of resource action names. It is important that 'new' precede 'show'
+  resourceActions:
+    ['index', 'new', 'show', 'edit', 'update', 'create', 'destroy']
+
+
+  # Returns an object mapping each resource route name to a function which binds the route
+  resourceMappings: (controllerName) ->
     {GET, POST, PUT, DELETE} = @getRouteDirectives()
     singularName = singularize controllerName
     pluralName = pluralize controllerName
 
-    GET "/#{controllerName}",          to: "#{controllerName}#index", as: pluralName
-    GET "/#{controllerName}/new",      to: "#{controllerName}#new",   as: "new_#{singularName}"
-    GET "/#{controllerName}/:id",      to: "#{controllerName}#show",  as: singularName
-    GET "/#{controllerName}/:id/edit", to: "#{controllerName}#edit",  as: "edit_#{singularName}"
-    PUT "/#{controllerName}/:id",      to: "#{controllerName}#update"
-    POST   "/#{controllerName}",       to: "#{controllerName}#create"
-    DELETE "/#{controllerName}/:id",   to: "#{controllerName}#destroy"
+    index:   -> GET "/#{controllerName}",          to: "#{controllerName}#index",   as: pluralName
+    new:     -> GET "/#{controllerName}/new",      to: "#{controllerName}#new",     as: "new_#{singularName}"
+    show:    -> GET "/#{controllerName}/:id",      to: "#{controllerName}#show",    as: singularName
+    edit:    -> GET "/#{controllerName}/:id/edit", to: "#{controllerName}#edit",    as: "edit_#{singularName}"
+    update:  -> PUT "/#{controllerName}/:id",      to: "#{controllerName}#update",  as: singularName
+    create:  -> POST "/#{controllerName}",         to: "#{controllerName}#create",  as: pluralName
+    destroy: -> DELETE "/#{controllerName}/:id",   to: "#{controllerName}#destroy", as: singularName
 
+
+  # A helper method for automatically binding restful controllers in a routes file
+  # This is passed as "resources" to the routes file function parameter hash
+  # Routes can be filtered with the 'only:' option.
+  # E.g. resources 'users', only: ['index', 'show']
+  resourcesDirective: (controllerName, opts) =>
+    includedActions = if opts?.only?
+      _.intersection @resourceActions, opts.only
+    else
+      @resourceActions
+    mappings = @resourceMappings controllerName
+
+    mappings[action]() for action in includedActions
 
   # Middleware to set reverse routes on req.locals
   setReverseRoutesOnReqLocals: (req, res, next) =>

--- a/test/feature/finding_routes.feature
+++ b/test/feature/finding_routes.feature
@@ -92,3 +92,33 @@ Feature: Finding routes
       | GET     | /users/1/edit | users edit    |
       | PUT     | /users/1      | users update  |
       | DELETE  | /users/1      | users destroy |
+
+
+  Scenario Outline: restricting generated restful routes
+    Given a file "routes.coffee" with the contents
+      """
+      module.exports = ({ resources }) ->
+        resources 'users', only: ['index', 'show', 'new', 'create']
+      """
+    And a file "controllers/users.coffee" with the contents
+      """
+      class UsersController
+        index:   (req, res) -> res.end 'users index'
+        new:     (req, res) -> res.end 'users new'
+        create:  (req, res) -> res.end 'users create'
+        show:    (req, res) -> res.end 'users show'
+      module.exports = UsersController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL           | RESPONSE BODY            |
+      | GET     | /users        | users index              |
+      | GET     | /users/new    | users new                |
+      | POST    | /users        | users create             |
+      | GET     | /users/1      | users show               |
+      | GET     | /users/1/edit | Cannot GET /users/1/edit |
+      | PUT     | /users/1      | Cannot PUT /users/1      |
+      | DELETE  | /users/1      | Cannot DELETE /users/1   |

--- a/test/feature/step_definitions/request_definitions.coffee
+++ b/test/feature/step_definitions/request_definitions.coffee
@@ -16,5 +16,5 @@ module.exports = ->
 
 
   @Then /^the response body should be "([^"]+)"$/, (responseBody, done) ->
-    expect(@responseBody).to.equal responseBody
+    expect(@responseBody.trim()).to.equal responseBody
     done()


### PR DESCRIPTION
  The following:
    resources 'users', only: ['index', 'show']

  Would generate the equivalent of:
    GET '/users', to: 'users#index', as: 'users'
    GET '/users/:id', to: 'users#show', as: 'user'

Note that if the 'new' route is excluded, and 'show' is not, then the 'show' route would catch `/users/new`. I don't think any guard should be added for that, however, as the behavior is just a consequence of how routes are matched and would happen with any setup.
