### PR TITLE
routes in jade template

### DIFF
--- a/src/reverse_route.coffee
+++ b/src/reverse_route.coffee
@@ -1,22 +1,14 @@
 class ReverseRoute
 
   constructor: ({@path, @method}) ->
-    @length = @path.length
-
-    # Enable single character access
-    @[i] = character for character, i in @path
 
 
-  # Forward String methods
-  indexOf: -> @path.indexOf arguments...
+  toString: ->
+    @path
 
-  match: -> @path.match arguments...
 
-  slice: -> @path.slice arguments...
-
-  toString: -> @path
-
-  valueOf: -> @path
+  valueOf: ->
+    @path
 
 
 module.exports = ReverseRoute

--- a/src/reverse_route.coffee
+++ b/src/reverse_route.coffee
@@ -1,11 +1,22 @@
-class ReverseRoute extends String
+class ReverseRoute
 
   constructor: ({@path, @method}) ->
-    super @path
+    @length = @path.length
+
+    # Enable single character access
+    @[i] = character for character, i in @path
 
 
-  toString: ->
-    @path
+  # Forward String methods
+  indexOf: -> @path.indexOf arguments...
+
+  match: -> @path.match arguments...
+
+  slice: -> @path.slice arguments...
+
+  toString: -> @path
+
+  valueOf: -> @path
 
 
 module.exports = ReverseRoute

--- a/test/spec/reverse_route_spec.coffee
+++ b/test/spec/reverse_route_spec.coffee
@@ -1,0 +1,39 @@
+ReverseRoute = require '../../src/reverse_route'
+
+
+describe 'ReverseRoute', ->
+
+  beforeEach ->
+    @route = new ReverseRoute
+      path: '/some/path'
+      method: 'GET'
+
+  it 'exposes path', ->
+    expect(@route.path).to.equal '/some/path'
+
+  it 'exposes method', ->
+    expect(@route.method).to.equal 'GET'
+
+
+  describe 'behaves like a string', ->
+
+    it 'has a toString method', ->
+      expect(@route.toString()).to.equal '/some/path'
+
+    it 'has a valueOf method', ->
+      expect(@route.valueOf()).to.equal '/some/path'
+
+    it 'has an indexOf method', ->
+      expect(@route.indexOf 'p').to.equal 6
+
+    it 'has a match method', ->
+      expect(@route.match(/.+/)[0]).to.equal '/some/path'
+
+    it 'has a length parameter', ->
+      expect(@route.length).to.equal 10
+
+    it 'allows accessing single characters', ->
+      expect(@route[1]).to.equal 's'
+
+    it 'allows slicing', ->
+      expect(@route[5..9]).to.equal '/path'

--- a/test/spec/reverse_route_spec.coffee
+++ b/test/spec/reverse_route_spec.coffee
@@ -8,14 +8,14 @@ describe 'ReverseRoute', ->
       path: '/some/path'
       method: 'GET'
 
-  it 'exposes path', ->
+  it 'exposes the URL path for this route through "path"', ->
     expect(@route.path).to.equal '/some/path'
 
-  it 'exposes method', ->
+  it 'exposes the URL method for this route through "method"', ->
     expect(@route.method).to.equal 'GET'
 
-  it 'has a toString method', ->
+  it 'exposes the URL path for this route through "toString"', ->
     expect(@route.toString()).to.equal '/some/path'
 
-  it 'has a valueOf method', ->
+  it 'exposes the URL path for this route through "valueOf"', ->
     expect(@route.valueOf()).to.equal '/some/path'

--- a/test/spec/reverse_route_spec.coffee
+++ b/test/spec/reverse_route_spec.coffee
@@ -14,26 +14,8 @@ describe 'ReverseRoute', ->
   it 'exposes method', ->
     expect(@route.method).to.equal 'GET'
 
+  it 'has a toString method', ->
+    expect(@route.toString()).to.equal '/some/path'
 
-  describe 'behaves like a string', ->
-
-    it 'has a toString method', ->
-      expect(@route.toString()).to.equal '/some/path'
-
-    it 'has a valueOf method', ->
-      expect(@route.valueOf()).to.equal '/some/path'
-
-    it 'has an indexOf method', ->
-      expect(@route.indexOf 'p').to.equal 6
-
-    it 'has a match method', ->
-      expect(@route.match(/.+/)[0]).to.equal '/some/path'
-
-    it 'has a length parameter', ->
-      expect(@route.length).to.equal 10
-
-    it 'allows accessing single characters', ->
-      expect(@route[1]).to.equal 's'
-
-    it 'allows slicing', ->
-      expect(@route[5..9]).to.equal '/path'
+  it 'has a valueOf method', ->
+    expect(@route.valueOf()).to.equal '/some/path'


### PR DESCRIPTION
```
script(type='text/javascript' src=routes.applicationJs())
```

Gives me the error

```
String.prototype.valueOf is not generic
  at Route.valueOf (native)
```
