### PR TITLE
Add support for scoped routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,33 @@ module.exports = ({resources}) ->
   resources 'posts', except: ['index']
 ```
 
+## Scoped routing
+The `scope` helper can be used to create a prefexed set of routes:
+```
+# routes.coffee
+module.exports = ({GET, scope}) ->
+  scope '/api', ->
+    GET '/users', to: 'users#index'
+    GET '/widgets', to: 'widgets#index'
+```
+
+This is equivalent to:
+```
+# routes.coffee
+module.exports = ({GET}) ->
+  GET '/api/users', to: 'users#index'
+  GET '/api/widgets', to: 'widgets#index'
+```
+
+Resources are also supported as well as nested scopes:
+```
+# routes.coffee
+module.exports = ({GET, resources, scope}) ->
+  scope '/api', ->
+    scope '/v1', ->
+      resources 'users'
+      GET '/widgets', to: 'widgets#index'
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module.exports = ({resources}) ->
 ```
 
 ## Scoped routing
-The `scope` helper can be used to create a prefexed set of routes:
+The `scope` helper can be used to create a prefixed set of routes:
 ```
 # routes.coffee
 module.exports = ({GET, scope}) ->
@@ -145,7 +145,7 @@ module.exports = ({GET}) ->
   GET '/api/widgets', to: 'widgets#index'
 ```
 
-Resources are also supported as well as nested scopes:
+Scopes can also be nested:
 ```
 # routes.coffee
 module.exports = ({GET, resources, scope}) ->

--- a/src/routes_initializer.coffee
+++ b/src/routes_initializer.coffee
@@ -1,7 +1,6 @@
 _ = require 'lodash'
 camelCase = require 'camel-case'
 {pluralize, singularize} = require 'inflection'
-path = require 'path'
 URLFormatter = require './url_formatter'
 
 
@@ -25,7 +24,7 @@ class RoutesInitializer
   # Returns a route directive for a specific http method to be called in a routes file
   getHttpDirective: (httpMethod) ->
     (url, {to, as}) =>
-      url = path.posix.normalize "/#{@_scope.join '/'}/#{url}"
+      url = @_normalizeUrl "#{@_scope.join '/'}/#{url}"
       [controllerName, actionName] = to.split '#'
       @_routes.push {httpMethod, url, controllerName, actionName}
       @registerReverseRoute {routeName: as, httpMethod, url} if as?
@@ -87,6 +86,9 @@ class RoutesInitializer
 
 
   toArray: -> @_routes
+
+  _normalizeUrl: (path) ->
+    "/#{_.compact(path.split('/')).join('/')}"
 
 
 module.exports = RoutesInitializer

--- a/src/routes_initializer.coffee
+++ b/src/routes_initializer.coffee
@@ -1,6 +1,7 @@
 _ = require 'lodash'
 camelCase = require 'camel-case'
 {pluralize, singularize} = require 'inflection'
+path = require 'path'
 URLFormatter = require './url_formatter'
 
 
@@ -17,14 +18,14 @@ class RoutesInitializer
 
   constructor: (@routesFile, @reverseRoutes, @addRoute) ->
     @_routes = []
-    @_scope = ''
+    @_scope = []
     require(@routesFile) @getRouteDirectives()
 
 
   # Returns a route directive for a specific http method to be called in a routes file
   getHttpDirective: (httpMethod) ->
     (url, {to, as}) =>
-      url = "#{@_scope}#{url}"
+      url = path.posix.normalize "/#{@_scope.join '/'}/#{url}"
       [controllerName, actionName] = to.split '#'
       @_routes.push {httpMethod, url, controllerName, actionName}
       @registerReverseRoute {routeName: as, httpMethod, url} if as?
@@ -80,10 +81,9 @@ class RoutesInitializer
 
   # Adjust the current scope for scoped routes
   scopeDirective: (scopeName, scopedRoutes) =>
-    originalScope = @_scope
-    @_scope = "#{@_scope}#{scopeName}"
+    @_scope.push scopeName
     scopedRoutes()
-    @_scope = originalScope
+    @_scope.pop scopeName
 
 
   toArray: -> @_routes

--- a/test/feature/scoped_routes.feature
+++ b/test/feature/scoped_routes.feature
@@ -65,21 +65,15 @@ Feature: Scoped routes
   Scenario Outline: nested scoped routing
     Given a file "routes.coffee" with the content
       """
-      module.exports = ({ resources, scope }) ->
+      module.exports = ({ GET, scope }) ->
         scope '/api', ->
           scope '/v1', ->
-            resources 'users'
+            GET 'users', to: 'users#index'
       """
     And a file "controllers/users_controller.coffee" with the content
       """
       class UsersController
         index:   (req, res) -> res.end 'users index'
-        new:     (req, res) -> res.end 'users new'
-        create:  (req, res) -> res.end 'users create'
-        show:    (req, res) -> res.end 'users show'
-        edit:    (req, res) -> res.end 'users edit'
-        update:  (req, res) -> res.end 'users update'
-        destroy: (req, res) -> res.end 'users destroy'
       module.exports = UsersController
       """
     And an exprestive app using defaults
@@ -89,9 +83,3 @@ Feature: Scoped routes
     Examples:
       | REQUEST | URL                  | RESPONSE BODY |
       | GET     | /api/v1/users        | users index   |
-      | GET     | /api/v1/users/new    | users new     |
-      | POST    | /api/v1/users        | users create  |
-      | GET     | /api/v1/users/1      | users show    |
-      | GET     | /api/v1/users/1/edit | users edit    |
-      | PUT     | /api/v1/users/1      | users update  |
-      | DELETE  | /api/v1/users/1      | users destroy |

--- a/test/feature/scoped_routes.feature
+++ b/test/feature/scoped_routes.feature
@@ -1,0 +1,97 @@
+Feature: Scoped routes
+
+  Scenario Outline: basic scoped routing
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ scope, GET }) ->
+        scope '/api', ->
+          GET '/users', to: 'users#index'
+        GET '/widgets', to: 'widgets#index'
+      """
+    And a file "controllers/users_controller.coffee" with the content
+      """
+      class UsersController
+        index:   (req, res) -> res.end 'users index'
+      module.exports = UsersController
+      """
+    And a file "controllers/widgets_controller.coffee" with the content
+      """
+      class WidgetsController
+        index:   (req, res) -> res.end 'widgets index'
+      module.exports = WidgetsController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL               | RESPONSE BODY   |
+      | GET     | /api/users        | users index     |
+      | GET     | /widgets          | widgets index   |
+
+  Scenario Outline: resource scoped routing
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ resources, scope }) ->
+        scope '/api', ->
+          resources 'users'
+      """
+    And a file "controllers/users_controller.coffee" with the content
+      """
+      class UsersController
+        index:   (req, res) -> res.end 'users index'
+        new:     (req, res) -> res.end 'users new'
+        create:  (req, res) -> res.end 'users create'
+        show:    (req, res) -> res.end 'users show'
+        edit:    (req, res) -> res.end 'users edit'
+        update:  (req, res) -> res.end 'users update'
+        destroy: (req, res) -> res.end 'users destroy'
+      module.exports = UsersController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL               | RESPONSE BODY |
+      | GET     | /api/users        | users index   |
+      | GET     | /api/users/new    | users new     |
+      | POST    | /api/users        | users create  |
+      | GET     | /api/users/1      | users show    |
+      | GET     | /api/users/1/edit | users edit    |
+      | PUT     | /api/users/1      | users update  |
+      | DELETE  | /api/users/1      | users destroy |
+
+  Scenario Outline: nested scoped routing
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ resources, scope }) ->
+        scope '/api', ->
+          scope '/v1', ->
+            resources 'users'
+      """
+    And a file "controllers/users_controller.coffee" with the content
+      """
+      class UsersController
+        index:   (req, res) -> res.end 'users index'
+        new:     (req, res) -> res.end 'users new'
+        create:  (req, res) -> res.end 'users create'
+        show:    (req, res) -> res.end 'users show'
+        edit:    (req, res) -> res.end 'users edit'
+        update:  (req, res) -> res.end 'users update'
+        destroy: (req, res) -> res.end 'users destroy'
+      module.exports = UsersController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL                  | RESPONSE BODY |
+      | GET     | /api/v1/users        | users index   |
+      | GET     | /api/v1/users/new    | users new     |
+      | POST    | /api/v1/users        | users create  |
+      | GET     | /api/v1/users/1      | users show    |
+      | GET     | /api/v1/users/1/edit | users edit    |
+      | PUT     | /api/v1/users/1      | users update  |
+      | DELETE  | /api/v1/users/1      | users destroy |


### PR DESCRIPTION
Implements #32 - @alexdavid, @charlierudolph please take a look when you have a chance.
- New `scope` directive accepts a name and function containing more directives
- Allows for nested scopes
- Works with standard routes and resources

Usage:
module.exports = ({ scope, GET }) ->
  scope '/api', ->
    GET '/users', to: 'users#index'
