### PR TITLE
Support middleware for controller actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ module.exports = ({GET, resources, scope}) ->
       GET '/widgets', to: 'widgets#index'
 ```
 
+## Middleware Support
+
+Adding per-route middleware can be done in the controller
+by using the `middleware` property.
+
+```coffeescript
+# controllers/hello_world_controller.coffee
+  someMiddleware = require 'some-middleware'
+
+  class HelloWorldController
+    middleware:
+      index: someMiddleware
+
+    index: (req, res) ->
+      res.end 'hello world'
+
+  module.exports = HelloWorldController
+```
+
+The specified middleware will be inserted in the chain before the controller
+action. An array of middleware can also be specified and they will be
+inserted in the chain in the specified order.
+
 ## Options
 
 Options are provided to the _exprestive_ function.

--- a/src/controller_initializer.coffee
+++ b/src/controller_initializer.coffee
@@ -32,6 +32,7 @@ class ControllerInitializer
       controllerName = camelCase Controller.name.replace /Controller$/, ''
       @controllers[controllerName] = new Controller @dependencies
 
+
   # Finds any middleware defined for the controller action
   middlewareFor: ({controllerName, actionName}) ->
     controller = @controllers[camelCase controllerName]

--- a/src/controller_initializer.coffee
+++ b/src/controller_initializer.coffee
@@ -32,5 +32,13 @@ class ControllerInitializer
       controllerName = camelCase Controller.name.replace /Controller$/, ''
       @controllers[controllerName] = new Controller @dependencies
 
+  # Finds any middleware defined for the controller action
+  middlewareFor: ({controllerName, actionName}) ->
+    controller = @controllers[camelCase controllerName]
+    return [] unless controller?
+    return [] unless typeof controller[actionName] is 'function'
+    return [] unless controller.middleware?[actionName]?
+    [].concat controller.middleware[actionName]
+
 
 module.exports = ControllerInitializer

--- a/src/exprestive.coffee
+++ b/src/exprestive.coffee
@@ -49,7 +49,8 @@ class Exprestive
 
   # Registers a route on @middlewareRouter
   addRoute: ({httpMethod, url, controllerName, actionName}) =>
-    @middlewareRouter[httpMethod.toLowerCase()] url, (args...) =>
+    middleware = @controllers.middlewareFor {controllerName, actionName}
+    @middlewareRouter[httpMethod.toLowerCase()] url, middleware..., (args...) =>
       @controllers.applyAction {controllerName, actionName, args}
 
 

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -1,0 +1,55 @@
+Feature: Middleware support
+
+  Scenario Outline: simple middleware support
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ GET }) ->
+        GET '/users', to: 'users#index'
+      """
+    And a file "controllers/users_controller.coffee" with the content
+      """
+      class UsersController
+        middleware:
+          index: (req, res, next) ->
+            req.custom = 'foo'
+            next()
+        index:   (req, res) -> res.end req.custom
+      module.exports = UsersController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL                  | RESPONSE BODY |
+      | GET     | /users               | foo           |
+
+  Scenario Outline: multiple middleware support
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ GET }) ->
+        GET '/users', to: 'users#index'
+      """
+    And a file "controllers/users_controller.coffee" with the content
+      """
+      middle1 = (req, res, next) ->
+        req.custom1 = 'foo'
+        next()
+
+      middle2 = (req, res, next) ->
+        req.custom2 = 'bar'
+        next()
+
+      class UsersController
+        middleware:
+          index: [middle1, middle2]
+        index:   (req, res) -> res.end "#{req.custom1} #{req.custom2}"
+      module.exports = UsersController
+      """
+    And an exprestive app using defaults
+    When making a <REQUEST> request to "<URL>"
+    Then the response body should be "<RESPONSE BODY>"
+
+    Examples:
+      | REQUEST | URL                  | RESPONSE BODY |
+      | GET     | /users               | foo bar       |

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -16,7 +16,7 @@ Feature: Middleware support
         middleware:
           index: middle
 
-        index:   (req, res) -> res.end req.custom
+        index: (req, res) -> res.end req.custom
       module.exports = UsersController
       """
     And an exprestive app using defaults
@@ -24,8 +24,9 @@ Feature: Middleware support
     Then the response body should be "<RESPONSE BODY>"
 
     Examples:
-      | REQUEST | URL                  | RESPONSE BODY |
-      | GET     | /users               | foo           |
+      | REQUEST | URL     | RESPONSE BODY |
+      | GET     | /users  | foo           |
+
 
   Scenario Outline: multiple middleware support
     Given a file "routes.coffee" with the content
@@ -46,7 +47,8 @@ Feature: Middleware support
       class UsersController
         middleware:
           index: [middle1, middle2]
-        index:   (req, res) -> res.end "#{req.custom1} #{req.custom2}"
+
+        index: (req, res) -> res.end "#{req.custom1} #{req.custom2}"
       module.exports = UsersController
       """
     And an exprestive app using defaults
@@ -54,5 +56,5 @@ Feature: Middleware support
     Then the response body should be "<RESPONSE BODY>"
 
     Examples:
-      | REQUEST | URL                  | RESPONSE BODY |
-      | GET     | /users               | foo bar       |
+      | REQUEST | URL     | RESPONSE BODY |
+      | GET     | /users  | foo bar       |

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -8,11 +8,14 @@ Feature: Middleware support
       """
     And a file "controllers/users_controller.coffee" with the content
       """
+      middle = (req, res, next) ->
+        req.custom = 'foo'
+        next()
+
       class UsersController
         middleware:
-          index: (req, res, next) ->
-            req.custom = 'foo'
-            next()
+          index: middle
+
         index:   (req, res) -> res.end req.custom
       module.exports = UsersController
       """

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -24,8 +24,8 @@ Feature: Middleware support
     Then the response body should be "<RESPONSE BODY>"
 
     Examples:
-      | REQUEST | URL     | RESPONSE BODY |
-      | GET     | /users  | foo           |
+      | REQUEST | URL    | RESPONSE BODY |
+      | GET     | /users | foo           |
 
 
   Scenario Outline: multiple middleware support
@@ -56,5 +56,5 @@ Feature: Middleware support
     Then the response body should be "<RESPONSE BODY>"
 
     Examples:
-      | REQUEST | URL     | RESPONSE BODY |
-      | GET     | /users  | foo bar       |
+      | REQUEST | URL    | RESPONSE BODY |
+      | GET     | /users | foo bar       |


### PR DESCRIPTION
@alexdavid 

Added support for putting a `middleware` key on your controller class.

If specified, it will add the listed middleware into the route handler chain.

```
middle = (req, res, next) ->
  req.custom = 'foo'
  next()

class UsersController
  middleware:
    index: middle

  index:   (req, res) -> res.end req.custom

module.exports = UsersController
```

Supports single or arrays of middleware for each entry. See feature for example of single and array usage.
