### PR TITLE
Remove devDependency status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://img.shields.io/circleci/project/alexdavid/exprestive/master.svg)](https://circleci.com/gh/alexdavid/exprestive)
 [![Dependency Status](https://david-dm.org/alexdavid/exprestive.svg)](https://david-dm.org/alexdavid/exprestive)
-[![devDependency Status](https://david-dm.org/alexdavid/exprestive/dev-status.svg)](https://david-dm.org/alexdavid/exprestive#info=devDependencies)
 
 A RESTful routing middleware for [Express.js](http://expressjs.com).
 


### PR DESCRIPTION
@alexdavid @charlierudolph 

I think showing a badge for the production dependencies makes the most sense, since this is relevant for other people who look at our Readme. Whether we use slightly outdated tools for development of this library is internal and a lot less critical. Nobody except our own shiny-technology syndrome is affected if we use an older version of chai for testing, and there is no pressing need to upgrade if that's the case. 

So the devDependencies badge is more or less meaningless information that only adds noise and unnecessary yellow to the readme, and I'm removing the badge for devDependencies here. Not 100% sure though. What do you think?

Dev-Dependencies will still be updated when production dependencies are updated, or whenever we want. 
