### PR TITLE
cleanup: specify files instead of using npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-CONTRIBUTING.md
-gulpfile.coffee
-src/
-test/

--- a/package.json
+++ b/package.json
@@ -51,5 +51,6 @@
     "unit-tests": "mycha",
     "update": "david update && npm test",
     "update-check": "david ; echo"
-  }
+  },
+  "files": ["lib"]
 }


### PR DESCRIPTION
@alexdavid @kevgo 

I think we should be using this approach more. 
