### PR TITLE
Add routes to middleware context

### DIFF
--- a/src/controller_initializer.coffee
+++ b/src/controller_initializer.coffee
@@ -9,6 +9,7 @@ class ControllerInitializer
   constructor: ({@appDir, @controllersPattern, @dependencies, @reverseRoutes}) ->
     @controllers = {}
     @initializeControllers()
+    @middlewareContext = routes: @reverseRoutes
 
 
   # Calls a controller action with args
@@ -36,6 +37,11 @@ class ControllerInitializer
   # Finds any middleware defined for the controller action
   middlewareFor: ({controllerName, actionName}) ->
     controller = @controllers[camelCase controllerName]
+    @getMiddlewareFunctions({controller, actionName}).map (middleware) =>
+      middleware.bind @middlewareContext
+
+
+  getMiddlewareFunctions: ({controller, actionName}) ->
     return [] unless controller?
     return [] unless typeof controller[actionName] is 'function'
     return [] unless controller.middleware?[actionName]?

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -69,7 +69,6 @@ Feature: Middleware support
           index: redirectToDashboard
 
         index: (req, res) ->
-          res.end()
 
         dashboard: (req, res) ->
           res.end()

--- a/test/feature/middleware_support.feature
+++ b/test/feature/middleware_support.feature
@@ -49,3 +49,33 @@ Feature: Middleware support
     And an exprestive app using defaults
     When making a GET request to "/users"
     Then the response body should be "foo bar"
+
+
+  Scenario: referencing routes in middleware
+    Given a file "routes.coffee" with the content
+      """
+      module.exports = ({ GET }) ->
+        GET '/', to: 'home#index'
+        GET '/dashboard', to: 'home#dashboard', as: 'dashboard'
+      """
+    And a file "controllers/home_controller.coffee" with the content
+      """
+      redirectToDashboard = (req, res, next) ->
+        res.writeHead 301, Location: @routes.dashboard()
+        res.end()
+
+      class HomeController
+        middleware:
+          index: redirectToDashboard
+
+        index: (req, res) ->
+          res.end()
+
+        dashboard: (req, res) ->
+          res.end()
+
+      module.exports = HomeController
+      """
+    And an exprestive app using defaults
+    When making a GET request to "/"
+    Then I am redirected to "/dashboard"

--- a/test/feature/step_definitions/request_definitions.coffee
+++ b/test/feature/step_definitions/request_definitions.coffee
@@ -6,6 +6,7 @@ module.exports = ->
   @When /^making a (GET|POST|PUT|DELETE) request to "(.+)"$/, (httpMethod, urlPath, done) ->
     @makeRequest httpMethod, urlPath, (err, response, @responseBody) =>
       return done err if err
+      @requestPath = response.request.path
       @statusCode = response.statusCode
       done()
 
@@ -16,3 +17,7 @@ module.exports = ->
 
   @Then /^the response body should be "([^"]+)"$/, (responseBody) ->
     expect(@responseBody.trim()).to.equal responseBody
+
+
+  @Then /^I am redirected to "([^"]+)"$/, (expectedPath) ->
+    expect(@requestPath).to.equal expectedPath


### PR DESCRIPTION
@charlierudolph @kevgo 

This adds `@routes` to middleware functions which is useful since some middleware does redirects, and using the reverse routing would be great for those.
